### PR TITLE
Feat settings widget

### DIFF
--- a/src/quandary/ui/components.py
+++ b/src/quandary/ui/components.py
@@ -3,9 +3,11 @@ from textual.containers import ScrollableContainer, VerticalScroll, Container
 from textual.widgets import Input, Static, Markdown, TabbedContent, Placeholder, Header, Footer, Pretty
 from textual.reactive import reactive
 from textual.screen import Screen
+from datetime import datetime
 
 from quandary.app.utils import run_quandary, run_lang_quandary
 from quandary.ui.widgets.SettingsTab import SettingsTab
+from quandary.ui.widgets.SwitchSetting import SwitchSetting
 
 class ResponsePane(Static):
     """A widget to view results."""
@@ -32,12 +34,9 @@ class QandAPane(Static):
 
 class DebugPane(Static):
     """a widget to view debug outputs."""
-    debug_data = [{ 
-        "key": "value",
-        "int": 123
-    }]
+    debug_data = [{ "DebugInitialised": f"{datetime.now()}" }]
     def compose(self) -> ComposeResult:
-        yield Pretty(self.debug_data)
+        yield Pretty(self.debug_data, id="debug_pane_output")
 
     def clear_debug_pane(self) -> None:
         """clears the debug pane."""
@@ -55,6 +54,15 @@ class TabbedNavigation(TabbedContent):
             yield ResponsePane()
             yield DebugPane()
             yield SettingsTab()
+
+    def on_switch_setting_changed(self, event: SwitchSetting.Changed) -> None:
+        """when a SwitchSetting is toggled, log that to the debug pane."""
+        debug_pane = self.query_one(DebugPane)
+        output = [{
+            "label": event.label,
+            "enabled": event.enabled
+        }]
+        debug_pane.append_debug_pane(output)
 
 class InputPane(Static):
     """A widget to accept and send input"""

--- a/src/quandary/ui/components.py
+++ b/src/quandary/ui/components.py
@@ -5,6 +5,7 @@ from textual.reactive import reactive
 from textual.screen import Screen
 
 from quandary.app.utils import run_quandary, run_lang_quandary
+from quandary.ui.widgets.SettingsTab import SettingsTab
 
 class ResponsePane(Static):
     """A widget to view results."""
@@ -53,7 +54,7 @@ class TabbedNavigation(TabbedContent):
         with TabbedContent("Response", "Debug", "Settings"):
             yield ResponsePane()
             yield DebugPane()
-            yield Placeholder()
+            yield SettingsTab()
 
 class InputPane(Static):
     """A widget to accept and send input"""

--- a/src/quandary/ui/components.py
+++ b/src/quandary/ui/components.py
@@ -59,7 +59,7 @@ class TabbedNavigation(TabbedContent):
         """when a SwitchSetting is toggled, log that to the debug pane."""
         debug_pane = self.query_one(DebugPane)
         output = [{
-            "label": event.label,
+            "id": event.id,
             "enabled": event.enabled
         }]
         debug_pane.append_debug_pane(output)

--- a/src/quandary/ui/widgets/SettingsTab.py
+++ b/src/quandary/ui/widgets/SettingsTab.py
@@ -1,0 +1,20 @@
+from textual.app import ComposeResult
+from textual.widget import Widget
+from textual.widgets import Placeholder
+
+class SettingsTab(Widget):
+    """the settings tab of the main navigation window."""
+    DEFAULT_CSS = """
+    SettingsTab {
+        layout: vertical;
+        width: auto;
+        height: auto;
+    }
+    SettingsTab > Label {
+        text-align: center;
+        width: 100%;
+    }
+    """
+
+    def compose(self) -> ComposeResult:
+        yield Placeholder()

--- a/src/quandary/ui/widgets/SettingsTab.py
+++ b/src/quandary/ui/widgets/SettingsTab.py
@@ -1,20 +1,22 @@
 from textual.app import ComposeResult
 from textual.widget import Widget
-from textual.widgets import Placeholder
+from textual.containers import Horizontal
+
+from quandary.ui.widgets.SwitchSetting import SwitchSetting
 
 class SettingsTab(Widget):
     """the settings tab of the main navigation window."""
+
     DEFAULT_CSS = """
     SettingsTab {
-        layout: vertical;
-        width: auto;
+        width: 1fr;
         height: auto;
-    }
-    SettingsTab > Label {
-        text-align: center;
-        width: 100%;
+        border: heavy $primary;
     }
     """
 
     def compose(self) -> ComposeResult:
-        yield Placeholder()
+        yield Horizontal(
+            SwitchSetting(enabled=True, description="Document Mode:      "),
+            classes="container"
+        )

--- a/src/quandary/ui/widgets/SettingsTab.py
+++ b/src/quandary/ui/widgets/SettingsTab.py
@@ -16,6 +16,6 @@ class SettingsTab(Static):
 
     def compose(self) -> ComposeResult:
         yield Horizontal(
-            SwitchSetting(enabled=True, label="Document Mode:      "),
+            SwitchSetting(id="setting_doc_mode", enabled=True, label="Document Mode:      "),
             classes="container"
         )

--- a/src/quandary/ui/widgets/SettingsTab.py
+++ b/src/quandary/ui/widgets/SettingsTab.py
@@ -1,10 +1,9 @@
 from textual.app import ComposeResult
-from textual.widget import Widget
 from textual.containers import Horizontal
-
+from textual.widgets import Static
 from quandary.ui.widgets.SwitchSetting import SwitchSetting
 
-class SettingsTab(Widget):
+class SettingsTab(Static):
     """the settings tab of the main navigation window."""
 
     DEFAULT_CSS = """
@@ -17,6 +16,6 @@ class SettingsTab(Widget):
 
     def compose(self) -> ComposeResult:
         yield Horizontal(
-            SwitchSetting(enabled=True, description="Document Mode:      "),
+            SwitchSetting(enabled=True, label="Document Mode:      "),
             classes="container"
         )

--- a/src/quandary/ui/widgets/SwitchSetting.py
+++ b/src/quandary/ui/widgets/SwitchSetting.py
@@ -4,7 +4,6 @@ from textual.reactive import reactive
 from textual.widgets import Static, Switch
 from textual.containers import Horizontal
 
-
 class SwitchSetting(Static):
     """A binary configuration setting, exposed as a switch with a descriptive label"""
 
@@ -31,18 +30,22 @@ class SwitchSetting(Static):
         width: auto;
     }
     """
-    label = "label_missing"
+
+    id = ""
     enabled = reactive(True)
+    label = "label_missing"
 
     class Changed(Message):
         """A message that is sent when a SwitchSetting is toggled"""
 
-        def __init__(self, label: str, enabled: bool) -> None:
+        def __init__(self, id: str, label: str, enabled: bool) -> None:
             super().__init__()
+            self.id = id
             self.label = label
             self.enabled = enabled
 
-    def __init__(self, label: str, enabled: bool) -> None:
+    def __init__(self, id:str, label: str, enabled: bool) -> None:
+        self.id = id
         self.enabled = enabled
         self.label = label
         super().__init__()
@@ -60,4 +63,4 @@ class SwitchSetting(Static):
         # update the widget state based on the event value
         self.enabled = event.value
         # bubble a message to the parent
-        self.post_message(self.Changed(label=self.label, enabled=self.enabled))
+        self.post_message(self.Changed(id=self.id, label=self.label, enabled=self.enabled))

--- a/src/quandary/ui/widgets/SwitchSetting.py
+++ b/src/quandary/ui/widgets/SwitchSetting.py
@@ -1,0 +1,55 @@
+from textual.app import ComposeResult
+from textual.message import Message
+from textual.reactive import reactive
+from textual.widget import Widget
+from textual.widgets import Static, Switch
+from textual.containers import Horizontal
+
+
+class SwitchSetting(Widget):
+    """A binary configuration setting, exposed as a switch with a descriptive label"""
+
+    DEFAULT_CSS = """
+    SwitchSetting {
+        width: auto;
+        height: auto;
+        border: heavy $secondary;
+    }
+
+    SwitchSetting > Switch {
+        height: auto;
+        width: auto;
+    }
+
+    .container {
+        height: auto;
+        width: auto;
+    }
+
+    .label {
+        height: 3;
+        content-align: center middle;
+        width: auto;
+    }
+    """
+    description = "default"
+    enabled = reactive(True)
+
+    def __init__(self, description: str, enabled: bool) -> None:
+        self.enabled = enabled
+        self.description = description
+        super().__init__()
+
+    def compose(self) -> ComposeResult:
+        yield Horizontal(
+            Static(self.description, classes="label"),
+            Switch(value=self.enabled),
+            classes="container"
+        )
+
+    class SwitchChanged(Message):
+        """A message that is sent when the switch is toggled"""
+
+        def __init__(self, enabled: bool) -> None:
+            super().__init__()
+            self.enabled = enabled

--- a/src/quandary/ui/widgets/SwitchSetting.py
+++ b/src/quandary/ui/widgets/SwitchSetting.py
@@ -1,12 +1,11 @@
 from textual.app import ComposeResult
 from textual.message import Message
 from textual.reactive import reactive
-from textual.widget import Widget
 from textual.widgets import Static, Switch
 from textual.containers import Horizontal
 
 
-class SwitchSetting(Widget):
+class SwitchSetting(Static):
     """A binary configuration setting, exposed as a switch with a descriptive label"""
 
     DEFAULT_CSS = """
@@ -32,31 +31,33 @@ class SwitchSetting(Widget):
         width: auto;
     }
     """
-    description = "default"
+    label = "label_missing"
     enabled = reactive(True)
 
-    class SwitchChanged(Message):
+    class Changed(Message):
         """A message that is sent when a SwitchSetting is toggled"""
 
-        def __init__(self, description: str, enabled: bool) -> None:
+        def __init__(self, label: str, enabled: bool) -> None:
             super().__init__()
-            self.description = description
+            self.label = label
             self.enabled = enabled
 
-    def __init__(self, description: str, enabled: bool) -> None:
+    def __init__(self, label: str, enabled: bool) -> None:
         self.enabled = enabled
-        self.description = description
+        self.label = label
         super().__init__()
 
     def compose(self) -> ComposeResult:
         yield Horizontal(
-            Static(self.description, classes="label"),
+            Static(self.label, classes="label"),
             Switch(value=self.enabled),
             classes="container"
         )
 
     def on_switch_changed(self, event: Switch.Changed):
+        # disable the bubbling of the initial Switch.Changed event
         event.stop()
+        # update the widget state based on the event value
         self.enabled = event.value
         # bubble a message to the parent
-        self.post_message(self.SwitchChanged(self.enabled, event.value))
+        self.post_message(self.Changed(label=self.label, enabled=self.enabled))

--- a/src/quandary/ui/widgets/SwitchSetting.py
+++ b/src/quandary/ui/widgets/SwitchSetting.py
@@ -35,6 +35,14 @@ class SwitchSetting(Widget):
     description = "default"
     enabled = reactive(True)
 
+    class SwitchChanged(Message):
+        """A message that is sent when a SwitchSetting is toggled"""
+
+        def __init__(self, description: str, enabled: bool) -> None:
+            super().__init__()
+            self.description = description
+            self.enabled = enabled
+
     def __init__(self, description: str, enabled: bool) -> None:
         self.enabled = enabled
         self.description = description
@@ -47,9 +55,8 @@ class SwitchSetting(Widget):
             classes="container"
         )
 
-    class SwitchChanged(Message):
-        """A message that is sent when the switch is toggled"""
-
-        def __init__(self, enabled: bool) -> None:
-            super().__init__()
-            self.enabled = enabled
+    def on_switch_changed(self, event: Switch.Changed):
+        event.stop()
+        self.enabled = event.value
+        # bubble a message to the parent
+        self.post_message(self.SwitchChanged(self.enabled, event.value))


### PR DESCRIPTION
# Description

- creates a `SettingsTab` widget for use in the `TabbedNavigation` widget
- extracts it into its own module
- bubbles unique messages up to the `TabbedNavigation` widget which handles them